### PR TITLE
Switch link underline from border-bottom to text-decoration

### DIFF
--- a/css/ids.css
+++ b/css/ids.css
@@ -3,7 +3,7 @@
     color: rgb(var(--ids__link-RGB));
     text-decoration: underline;
     text-decoration-thickness: 1px;
-    text-underline-offset: 4px;
+    text-underline-offset: 0.25em;
     text-decoration-color: rgba(var(--ids__link-RGB), 0.2);
     transition: color 0.5s ease, text-decoration 0.5s ease;
 

--- a/css/ids.css
+++ b/css/ids.css
@@ -2,6 +2,7 @@
   & a {
     color: rgb(var(--ids__link-RGB));
     text-decoration: underline;
+    will-change: color;
     text-decoration-thickness: 1px;
     text-underline-offset: 0.25em;
     text-decoration-color: rgba(var(--ids__link-RGB), 0.2);

--- a/css/ids.css
+++ b/css/ids.css
@@ -1,15 +1,16 @@
 .ids {
   & a {
     color: rgb(var(--ids__link-RGB));
-    border-bottom: 1px solid rgba(var(--ids__link-RGB), 0.2);
-    text-decoration: none;
-    transition: color 0.5s ease, border 0.5s ease;
-
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 4px;
+    text-decoration-color: rgba(var(--ids__link-RGB), 0.2);
+    transition: color 0.5s ease, text-decoration 0.5s ease;
 
     &:hover {
       color: rgb(var(--ids__hover-RGB));
-      border-bottom: 1px solid rgba(var(--ids__hover-RGB), 0.2);
-      transition: color 0s ease, border 0s ease;
+      text-decoration-color: rgba(var(--ids__hover-RGB), 0.2);
+      transition: color 0s ease, text-decoration 0s ease;
     }
   }
 
@@ -22,8 +23,6 @@
       line-height: 1.2;
     }
   }
-
-    
 
   & h1,
   & h2,
@@ -44,11 +43,11 @@
 
     &.S {
       font-size: 2.4em;
-      font-weight: 650;  
+      font-weight: 650;
     }
     &.XS {
       font-size: 1.5em;
-      font-weight: 600;  
+      font-weight: 600;
     }
   }
 
@@ -60,7 +59,7 @@
 
     &.XS {
       font-size: 1.5em;
-      font-weight: 600;  
+      font-weight: 600;
     }
   }
 
@@ -119,9 +118,9 @@
       &:before {
         position: absolute;
         left: 0;
-        content: '⋅ ';
+        content: "⋅ ";
       }
-    }    
+    }
   }
 
   & ol {
@@ -154,7 +153,6 @@
   }
 
   & code {
-   
     font-size: 0.9em;
     font-family: "Root UI";
     letter-spacing: 0.02em;
@@ -163,9 +161,7 @@
     border-radius: 0.2em;
     color: rgba(var(--ids__code-RGB), 1);
     background: rgba(var(--ids__text-RGB), 0.05);
-    
   }
-
 
   & figure {
     margin: 0 0 calc(var(--ids__density) * 0.5em) 0;
@@ -202,12 +198,7 @@
   }
 
   & table {
-
-
-
-
     & caption {
-
     }
   }
 
@@ -215,6 +206,4 @@
     border-top-color: rgba(var(--ids__text-RGB), 0.2);
     border-bottom: 0;
   }
-  
 }
-


### PR DESCRIPTION
text-decoration теперь поддерживает больше свойств, поэтому способ подчеркивания через border-bottom, можно считать устаревшим.

Ист.: https://bureau.ru/soviet/20230126